### PR TITLE
Add github action condition for pull request

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -2,6 +2,7 @@ name: IntelliJ Platform Plugin Compatibility
 
 on:
   push:
+  pull_request:
 
 jobs:
   compatibility:


### PR DESCRIPTION
Previously, the github-action was executed when the PR merged, but adding this condition also triggers the github-action on the PR.